### PR TITLE
Fixing broken link on TravisCI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Chennaipy Website
 
-![](https://travis-ci.org/Chennaipy/website.svg?branch=master)
+[![Build Status](https://travis-ci.org/Chennaipy/website.svg?branch=master)](https://travis-ci.org/Chennaipy/website)
 
 This is the repo for the Chennai Python User Group's website
 [http://chennaipy.org](http://chennaipy.org). The site is built


### PR DESCRIPTION
- It wasn't going to the right place. Instead of opening the link to the
  build, it was opening up the badge image
