### PR TITLE
Remove GitHub link from the sidebar.

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -25,11 +25,10 @@ LINKS = (('ILUGC', 'http://ilugc.in/'),
          ('PSSI', 'http://python.org.in/'),)
 
 # Social widget
-SOCIAL = (('github', 'https://github.com/chennaipy/'),
-          ('group', 'http://meetup.com/chennaipy/'),
+SOCIAL = (('group', 'http://meetup.com/chennaipy/'),
           ('comments', 'https://mail.python.org/mailman/listinfo/chennaipy'),
-          ('rss', 'feeds/all.atom.xml'),
-          ('twitter', 'http://twitter.com/chennaipy'),)
+          ('twitter', 'http://twitter.com/chennaipy'),
+          ('rss', 'feeds/all.atom.xml'),)
 
 DEFAULT_PAGINATION = False
 


### PR DESCRIPTION
Remove GitHub link from the sidebar, to reduce clutter, and re-arrange
icons. Fixes issue #10.
