### PR TITLE
Bumping pelican version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ Unidecode==0.04.16
 blinker==1.3
 docutils==0.12
 feedgenerator==1.7
-pelican==3.4.0
+pelican==3.5.0
 python-dateutil==2.2
 pytz==2014.7
 six==1.8.0


### PR DESCRIPTION
- Seems like they upgraded to 3.5.0 on 4th nov 2014
- This would handle build issues with #15 and #16 
