### PR TITLE
Fixed the October overflow bug

### DIFF
--- a/content/october-2014-meet-minutes.md
+++ b/content/october-2014-meet-minutes.md
@@ -7,7 +7,7 @@ Tags: Meeting Minutes
 <a
 href="http://photos2.meetupstatic.com/photos/event/4/b/5/d/highres_432439293.jpeg"><img
 src="http://photos2.meetupstatic.com/photos/event/4/b/5/d/event_432439293.jpeg"
-alt="Krishnan Explaining" style="float: right"></img></a>
+alt="Krishnan Explaining"></img></a>
 
 The first talk of the evening was given by Krishnan in Python Test
 Automation. He explained how Python could be used for all types of
@@ -55,7 +55,7 @@ black box
 <a
 href="http://photos2.meetupstatic.com/photos/event/4/c/3/8/highres_432439512.jpeg"><img
 src="http://photos2.meetupstatic.com/photos/event/4/c/3/8/event_432439512.jpeg"
-alt="Rengaraj Explaining" style="float: right"></img></a>
+alt="Rengaraj Explaining"></img></a>
 
 The second talk was given by Rengaraj on Docopt. Docopt is a python
 module used to generate an interface for your command line
@@ -76,7 +76,7 @@ to work
 <a
 href="http://photos2.meetupstatic.com/photos/event/5/3/8/9/highres_432441385.jpeg"><img
 src="http://photos2.meetupstatic.com/photos/event/5/3/8/9/event_432441385.jpeg"
-alt="Vijay Explaining" style="float: right"></img></a>
+alt="Vijay Explaining"></img></a>
 
 The last talk was given by Vijay Kumar on a problem he solved at his
 company using Python and some embedded hardware. He explained how at

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -6,6 +6,7 @@ AUTHOR = u'Vijay Kumar B.'
 SITENAME = u'Chennaipy'
 TAGLINE = u'Chennai Python User Group'
 SITEURL = ''
+FAVICON_URL = 'https://www.python.org/static/favicon.ico'
 
 SITE_LICENSE = 'Text is available under the Creative Commons Attribution-ShareAlike License.'
 


### PR DESCRIPTION
Fixes Chennaipy/website#39

Avoid using `style="float: right"` inline CSS as it causes image overflow in the meeting minutes page. Also avoid using long strings in the alt attribute of the img tag as some part of the string is skipped causing the end quote to be skipped as well. This causes the the meta information(like tag, date) to be displayed on the same line as that of the image(see November meetup minutes in the website).