### PR TITLE
Wait loop added to address Issue #84

### DIFF
--- a/develop_server.sh
+++ b/develop_server.sh
@@ -66,6 +66,12 @@ function start_up(){
   $PELICAN --debug --autoreload -r $INPUTDIR -o $OUTPUTDIR -s $CONFFILE $PELICANOPTS &
   pelican_pid=$!
   echo $pelican_pid > $PELICAN_PID
+  
+  while [ ! -e $OUTPUTDIR ];
+  do
+      sleep 1
+  done
+ 
   cd $OUTPUTDIR
   $PY -m pelican.server $port &
   srv_pid=$!


### PR DESCRIPTION
I have added a wait loop in startup function of deveserver shell script to avoid server pointing to topdirectory.

This fix can now able to point the output directory.
I request Maintainers to review it.