### PR TITLE
Add links to Chennai PyCon mailing list.

### DIFF
--- a/content/pages/about.md
+++ b/content/pages/about.md
@@ -61,4 +61,13 @@ the promotion of Python.
      <a href="http://chennaipy.slack.com" target="_blank">Discuss</a>
      </p>
      </div>
+     <div class="pure-u-1-2 cp-grid-sect">
+     <p>
+     <i class="fa fa-comments fa-4x" style="color:#55cc55"></i>
+     </p>
+     <p><strong>Chennai PyCon Mailing List</strong><br/>
+     <a href="http://chennaipy.org/mailman/listinfo/pycon_chennaipy.org" target="_blank">Join</a> |
+     <a href="http://chennaipy.org/pipermail/pycon_chennaipy.org/" target="_blank">Archives</a>
+     </p>
+     </div>
 </div>


### PR DESCRIPTION
It is really hard to tell people, at the meetups, how exactly to find
the Chennai PyCon mailing list. Adding a link in the front page, will
be helpful.