### PR TITLE
Convert Meeting Minutes to Markdown Format (June 2018 - November 2020)

### DIFF
--- a/content/april-2019-meeting-minutes.md
+++ b/content/april-2019-meeting-minutes.md
@@ -1,0 +1,72 @@
+Title: April 2019 Meetup - Meeting minutes
+Date: 2019-04-27 16:00
+Tags: Meeting Minutes
+Summary: The April 2019 Chennaipy meetup featured talks on **Causal Inference**, **Security Vulnerability in `http.cookiejar`**, and **Tech Talk Tips**.
+
+# ChennaiPy April 2019 Meetup - Meeting Minutes
+
+The meetup was held on **April 27, 2019**, at **Pramathi, Chennai**.
+
+---
+
+### Talk 1: Causal Inference
+**Speaker:** Dhanesh Kasinathan, Architect at Pramathi
+
+- **Machine Learning Workflow**: `Xnew -> model -> Ynew`.
+- **Objective 1**: Understanding **Causal Inference** and the difference between **correlation** and **causality**.
+- **Objective 2**: Exploring the **"Do-Why" framework** from Microsoft.
+- **User Activity on Xbox**: How the number of friends impacts user activity and interest in gaming.
+- **Decision-Making Process**: Counterfactual explanation and causal graphical models.
+- **Potential Outcomes Framework**: Introduced in the context of causal inference.
+- **Principal Component Analysis (PCA)**: For reducing the number of variables.
+
+---
+
+### Talk 2: Security Vulnerability in `http.cookiejar`
+**Speaker:** Karthikeyan Singaravelan, Contributor to CPython at HappyFox
+
+- **Cookie Jar**: A mechanism for storing and sharing cookies.
+- **Security Issue**: Prefix on domain name and suffix path in the path parameter was causing issues with Python's `request` object.
+- **Fix**: The security vulnerability was reported and fixed in an upcoming release.
+- Karthik shared his journey and the time it took to fix the issue and release the fix.
+
+---
+
+### Coffee Break and Networking
+
+---
+
+### Talk 3: A Talk on How to Give a Tech Talk
+**Speaker:** Naren
+
+- Provided tips and tricks for becoming a successful speaker at meetups and conferences.
+- **Key Tips**:
+  - What do you already know? What do you want to know? What do you want to be known for?
+  - **CFP (Call for Papers)**: The importance of a **strong title** and **elevator pitch**.
+  - **Slides**: Keep it simple. Always prepare **presentation notes**.
+  - **Demo**: Make it an essential part of your talk.
+  - **Stage Presence**: Practice in a "test environment", then move to "staging", and finally present in the "production environment" (conference).
+  - **Audience Engagement**: Always have a call to action for your audience.
+
+---
+
+### PyCon India Announcement
+
+- **Ticket sales** will be announced by the end of next month.
+- **Dates**: October 12-15, 2019, at **Chennai Trade Center**.
+- Events: Poster session, lightning talks, Dev spring for open-source contributions, and more.
+- **Sponsorship** opportunities are available.
+
+---
+
+### Lightning Talk: Fish Dance with Python
+**Speaker:** Robin
+
+- **Fish Dance**: Shared how Guido van Rossum was inspired by the "Fish Dance" to start the Python language.
+- **Python Tutor**: Introduced **pythontutor.com** to visualize Python execution, which also supports **C**, **C++**, and **Java**.
+
+---
+
+The meetup concluded with a lively discussion and networking.
+
+Meeting minutes contributed by **Narendran S. S.**.

--- a/content/august-2020-meeting-minutes.md
+++ b/content/august-2020-meeting-minutes.md
@@ -1,0 +1,82 @@
+Title: August 2020 ChennaiPy Meetup - Meeting Minutes
+Date: 2020-08-22 16:00
+Tags: Meeting Minutes
+Summary: The August 2020 ChennaiPy meetup featured talks on **Signal Processing with Python**, **Django web development**, **Flask rate limiting**, **Ray for distributed computing**, **Machine Learning for movie recommendations**, and more.
+
+# ChennaiPy August 2020 Meetup - Meeting Minutes
+
+The meetup took place on **August 22, 2020**, online due to the **Covid-19 pandemic**.
+
+---
+
+### Talk 1: Replacing MATLAB in Signal, Speech, Image and Video Processing
+**Speaker:** Dr. Senthilkumar R
+
+- **Python for Signal Processing**: Discussed how Python can replace MATLAB for signal, image, speech, and video processing.
+- **Tools**: Covered **matplotlib**, **numpy**, **scipy**, **pillow**, and **opencv** modules.
+- **Topics**: 
+  - **Correlation algorithms** and **windowing techniques** for filter design.
+  - **FIR filters** for signal processing.
+  - **Image Processing**: Explained techniques in image processing using **opencv**.
+  - **Video Processing** in **opencv**.
+- **Examples**: Demonstrated various image processing applications.
+
+---
+
+### Talk 2: Discussing about a Web Project and the Issues I am Facing in It
+**Speaker:** Lt Col CR Sundar
+
+- Shared his experience in programming, starting with almost no programming knowledge and gradually improving over four years.
+- Discussed issues faced while hosting a Django (Python) website and his decision to switch to PHP for a factory automation website.
+- The session was disconnected before the speaker could demonstrate the issues on his website.
+
+---
+
+### Talk 3: Using Global Variables in Flask
+**Speaker:** Rengaraj D
+
+- **Flask App**: Developed a Flask app to get the IP address of client requests and restrict access if the same IP address requests within 60 seconds (rate limiting).
+- **Problem**: The application faced issues when running with three processes using a global variable to track request times.
+- **Proposed Solution**: Use **application or request context**, and either use a database or track session IDs instead of global variables.
+
+---
+
+### Talk 4: Intro to Ray, A Framework for Distributed Computing
+**Speaker:** Krishna Sangeeth
+
+- **Introduction**: Explained the evolution of computers from Babbage's machine to supercomputers.
+- Discussed how **Moore's Law** is flattening and the need for distributed computing to solve computation power requirements.
+- **Ray Framework**: Demonstrated how Ray can solve issues in distributed computing using a driver and individual workers.
+
+---
+
+### Talk 5: How I Will Be Using ML in My Movie Recommendation and Social Networking Website
+**Speaker:** Sonam Pankaj
+
+- **Classes of Learning Problems**: Explained her use of **unsupervised learning** for movie recommendations.
+- **K-Means Algorithm**: Demonstrated how K-means can be used to classify data.
+- Discussed **Expectation Maximization (EM)** algorithm and **dimensionality reduction** techniques.
+
+---
+
+### Talk 6: Floating Point Pitfalls
+**Speaker:** Vijay Kumar
+
+- **Floating Point Arithmetic**: Displayed sample Python code to demonstrate pitfalls in floating point arithmetic.
+- **Binary Representation**: Discussed how fractional values are represented in binary and the algorithm to convert decimal to binary.
+- **Avoiding Pitfalls**: Suggested using the **decimal class** in Python to avoid floating point errors.
+
+---
+
+### Talk 7: Three Good Reasons You Should Buy a Ticket to PyCon India
+**Speaker:** Abishek Mishra
+
+- **PyCon India**: Discussed the significance of **PyCon India** and this year's **online conference**.
+- Explained the process of buying tickets and addressed doubts received through the chat.
+
+---
+
+### Talk 8: Test-Driven Teaching (TDT) in Python
+**Speaker:** Ashok Bakthavathsalam
+
+- **Introduction to TDT**: Explained how **Test-**

--- a/content/january-2019-meeting-minutes.md
+++ b/content/january-2019-meeting-minutes.md
@@ -1,0 +1,61 @@
+Title: ChennaiPy - January meetup - Meeting Minutes
+Date: 2019-01-27 16:00
+Tags: Meeting Minutes
+Summary: The January 2019 Chennaipy meetup featured talks on **Design Thinking**, **Porting Python applications** to Python 3, and **Medical Python Coding**.
+
+# ChennaiPy - January 2019 Meetup - Meeting Minutes
+
+The meetup was held on **January 27, 2019**, at **Crayond, Chennai**.
+
+---
+
+### Talk 1: Code for Change
+**Speaker:** Makesh Gopalakrishnan, Crayond @ Chennai
+
+- Discussed **"How Design Thinking can solve a problem?"** with an example of **Swiggy**.
+- Introduced the **"Be the Tree Hugger"** mobile app.
+- Inspirational quotes shared:
+  - "Mankind advanced, at the expense of Nature Depletion."
+  - "Be the Change, you wish to see in the world."
+  - "5% change the world and the remaining 95% live in it."
+
+---
+
+### Talk 2: Porting Python applications to support Python 2 and Python 3
+**Speaker:** Poruri Sai Rahul, Scientific Developer
+
+- Discussed **why** we need to port to Python 3:
+  - **Python 2 EOL 2020**.
+  - **Numpy** and **Pandas** stopped supporting Python 2 after December 21, 2018.
+- Discussed the **changes** required:
+  - Syntax changes like `print()`.
+  - Changes in results due to integer division (`2/3`).
+- **Tools for porting**:
+  - `flakes`, `python-modernize`, `__future`, and `six`.
+- **PPT**: [Link to Slides](https://github.com/rahulporuri/talks/blob/master/python_2_to_3.pdf)
+
+---
+
+### Talk 3: Uncharted territories in Medical Python Coding
+**Speaker:** Dr. Akilesh, UrSmiles32 @ Chennai
+
+- Brief talk on **IT in Healthcare**:
+  - **Machine Learning**, **Data Analysis**, and **Management**.
+- Long-running journey into **Image Processing** (XRAYs):
+  - Transition from **2D to 3D perspective**.
+  - Showcased examples of **Virtual Reality Surgeries** for doctors' practice.
+- **PPT**: [Link to Paper](https://www.researchgate.net/publication/330662391_Python_in_Medicine_A_Journey_into_unchartered_Territories)
+
+---
+
+### Lightning Talk: DIY Hosting for Online Privacy
+**Speaker:** Ganesh, Chennai
+
+- Shared insights on **serverless architecture** and the need for **online privacy**.
+- **Link to Paper**: [Hotnets DIY](https://cs.stanford.edu/~matei/papers/2017/hotnets_diy.pdf)
+
+---
+
+The meetup concluded with engaging discussions and valuable insights.
+
+Meeting minutes contributed by **Dinesh Kumar P**.

--- a/content/january-2020-meeting-minutes.md
+++ b/content/january-2020-meeting-minutes.md
@@ -1,0 +1,79 @@
+Title: MoM - January 25th, 2020 ChennaiPy Meetup
+Date: 2020-01-25 16:00
+Tags: Meeting Minutes
+Summary: The January 2020 ChennaiPy meetup included talks on **System Architecture**, **Air Pollution using Satellite Imagery**, and **Blockchain Apps using Python**.
+
+# ChennaiPy January 2020 Meetup - Meeting Minutes
+
+The meetup was held on **January 25, 2020**, at **IITM Chennai**.
+
+---
+
+### Introduction/Welcome Note
+- **Welcome** to the attendees and thanks to the **sponsor**.
+- **Agenda** for the day was explained.
+- Set the **context** about the meetup and its purpose.
+
+---
+
+### Talk 1: Types of System Architecture
+**Speaker:** Roopashree
+
+- **Monolithic Architecture**: Explained its pain points.
+- **Microservices**: What they are and why they are preferred.
+- **Challenges**: Discussed the challenges in building and deploying microservices.
+- **Solutions**: Explained various methods to overcome challenges.
+- **Pros & Cons**: Discussed scalability, load balancing, and caching in microservices.
+  
+**Q&A**:  
+- **Q:** How should we migrate from monolithic to microservices?  
+- **A:** Analyse the project, break it into smaller modules, and migrate one app at a time.
+
+---
+
+### Talk 2: Understanding Air Pollution using Satellite Imagery
+**Speaker:** Gokulavasan Murali
+
+- **Introduction to GIS**: Geographic Information System used to plot and analyze pollution data from a vertical/satellite view.
+- **Sentinel**: Used to collect pollution data.
+- **OSM**: Used to collect city boundaries.
+- **EO-Learn**: Introduced as a tool for processing satellite imagery.
+- **Demo**: Showed Diwali pollution (+1 & -1 day) in Delhi and Chennai.
+
+---
+
+### Talk 3: Developing Blockchain Apps using Python
+**Speaker:** Abhinav Srivastava
+
+- **Blockchain Development**: While Python is not used to build blockchain apps directly, it can be used with **Vyper** for Pythonic blockchain development.
+- **Blockchain Concepts**: Explained **Ethereum**, **Bitcoin**, and key blockchain terms:
+  - Distributed Ledger
+  - Mining
+  - Consensus (Proof of Stake & Proof of Work)
+  - Transaction
+  - Currency (Ether)
+  - Smart Contract
+- **Tools**: Vyper and **Web3** for building blockchain apps.
+
+---
+
+### Lightning Talks
+
+1. **Zen of Python**: A quick lightning talk on the philosophy of Python.
+2. **Colonel**: Demoed a few of his websites.
+3. **Chocolate Padmanaban**: Showed his way of visualizing Engineering maths using Python.
+
+---
+
+### Thanks Note
+**Speaker:** Vijay Kumar
+
+- Thanks to all the attendees and speakers for making the meetup a success.
+
+---
+
+### Group Photo with Attendees
+
+The meetup concluded with a group photo and networking.
+
+Meeting minutes contributed by **Gopinath P**.

--- a/content/july-2020-meeting-minutes.md
+++ b/content/july-2020-meeting-minutes.md
@@ -1,0 +1,87 @@
+Title: Meeting Minutes of 6/27/2020 ChennaiPy
+Date: 2020-07-25 15:00
+Tags: Meeting Minutes
+Summary: The July 2020 ChennaiPy meetup featured talks on **Role of Python in ETL**, **Cyclic Redundancy Check (CRC)**, **Django Setup**, **Machine Learning**, and **Kivy**.
+
+# ChennaiPy July 2020 Meetup - Meeting Minutes
+
+The meetup took place on **July 25, 2020**, at **IITM Chennai**.
+
+---
+
+### Due to Covid-19 pandemic, the meetup format was converted into online format from April 2020, and the 4th edition of the online event was conducted on **25.07.2020 at 3:00 PM**.
+
+The entire event was hosted by **Mr. Vijaykumar** and **Mr. Rengaraj**, the organizers of the meetup (**Chennaipy**). Around 77 members were registered for the event and 21 members witnessed the event online. The meeting was conducted through the link:
+
+[https://bbb.zilogic.com/b/adm-ynl-qrt](https://bbb.zilogic.com/b/adm-ynl-qrt)
+
+---
+
+### Mr. Vijaykumar briefed about the purpose of the meetup to the new members and listed out the agenda of the meetup. The first presenters were introduced to the members, and then he permitted the presenters one by one to deliver the talk.
+
+---
+
+### Talk 1: Starting Django Project The Right Way
+**Speaker:** Arvind Nedumaran
+
+- **Introduction to Django**: Arvind, an active Django Developer with 10 years of experience, explained how to set up a Django environment.
+- Covered **Directory Structure**, **Settings Configuration**, **Requirements**, **Environment Variables**, and **User Model**.
+- **Cookiecutter**: Explained the command-line utility that creates projects from project templates (like creating a Python package project).
+- The session ended with a **Q&A**.
+
+---
+
+### Talk 2: Machine Learning using Scikit-Learn
+**Speaker:** Dr. R. Senthilkumar, Assistant Professor, IRTT, Erode
+
+- **Introduction to Machine Learning**: Dr. Senthilkumar, with 10 years of experience in ML, explained classification methods and KNN (K-Nearest Neighbors).
+- Focused on extracting information from data using ML techniques.
+- Used the example of **Cauvery River pollution** and processed images obtained from the river basin.
+- **Tools**: **Anaconda package** and **Spyder IDE** were used to demonstrate the problem and visualize the output.
+- The session ended with a **Q&A**:
+  - **Arulalan.T**: "13 samples are not enough to compute PCA."
+  - **Dr. Senthilkumar**: "In real-time scenarios, more samples are required for accurate results."
+
+---
+
+### Talk 3: Introduction to Kivy
+**Speaker:** Dr. M. Muralidharan, Head, CS, Nehru Memorial College
+
+- **Introduction to Kivy**: Dr. Muralidharan, with 33 years of experience in teaching, introduced **Kivy** as an application framework for developing graphical user interface (GUI) apps.
+- Covered **installation procedures** and **architecture** of Kivy.
+- Ended the session with **demo programs**.
+- The session ended with a **Q&A**:
+  - **R. Senthilkumar**: "Can Kivy be installed on a 32-bit system?"
+  - **Dr. Muralidharan**: "Yes, Kivy can be installed on a 32-bit system, and if the user wants platform independence, they can set up **virtualenv**."
+
+---
+
+### Lightning Talk 1: PyCon 2020
+
+- **Speaker:** Mr. Rengaraj
+- He gave an idea about participating in **PyCon 2020**, an online event for disseminating Python knowledge and necessary techniques.
+- Encouraged members to **submit proposals** for **talk sessions** and **workshops**.
+
+---
+
+### Mr. Vijaykumar wrapped the session with a summation of the meetup and thanked the members. The meeting ended at **5:30 PM**.
+
+---
+
+### Open Slot:
+- **Ashok**: Recommended documentaries available on **Netflix**:
+  - **"Prediction by the Numbers"**.
+  - **"The Code"** (3 episodes).
+  - Context: These documentaries help relate abstract mathematical concepts (like Bayes' Theorem, fractals, and prime numbers) to real-life occurrences.
+
+- **Rengaraj**: Announcement for **PyCon India 2020**.
+  
+- **Pradeep**: Shared **MIT OpenCourseWare** [MIT OCW](https://ocw.mit.edu/index.htm) as a valuable learning resource.
+  
+- **Vijay Ravider**: Discussed **Python modules used in infrastructure-based provisioning services**.
+
+---
+
+The minutes were drafted by **Dr. M. Muralidharan**.
+
+---

--- a/content/june-2018-meeting-minutes.md
+++ b/content/june-2018-meeting-minutes.md
@@ -1,0 +1,55 @@
+Title: June Meet Minutes
+Date: 2018-06-23 16:00
+Tags: Meeting Minutes
+Summary: The June 2018 Chennaipy meetup featured 3 insightful talks: Powering Python with Rust, Presentation Tips, and Stack Frames and Tail Call Recursion in Python.
+
+# ChennaiPy June 2018 Meetup - Meeting Minutes
+
+The meeting was held on **June 23, 2018**, from **4 PM to 6:45 PM** at **BotVFX, Teynampet**.
+
+---
+
+### Talk 1: Powering Python with Rust
+**Speaker:** Ravi Shankar
+
+- **What is heavy computation?**
+- **Introduction to Rust** and its advantages over Python for computational tasks.
+- **Rust FFI with Python** for better performance and memory management.
+- Discussion on **memory management** in Rust vs. Python's garbage collection.
+- **Q&A Session**.
+
+---
+
+### Talk 2: Presentation Tips
+**Speaker:** Vijay
+
+- Introduction to **Pysangamam** and the importance of good presentations.
+- Types of talks and tips for better presentations.
+- **Poster presentation** and **demo presentations** to wow the audience.
+- **Submit a Proposal** for PySangamam [here](https://cfp.pysangamam.org/).
+- **Q&A Session**.
+
+---
+
+### Talk 3: Stack Frames and Tail Call Recursion in Python
+**Speaker:** Varun Dey
+
+- What are **stack frames** and how do recursive functions work behind the scenes?
+- Optimizing recursive functions by saving computing time and space.
+- Introduction to **tail call recursion** in Python.
+- **Benchmarking recursive functions**.
+- **Q&A Session**.
+
+---
+
+### Lightning Talk 1: Alternative Softwares
+**Speaker:** Abhishek Yadav
+
+- Discussed a list of alternative software solutions.
+- **Abhishek** will share the alternative software list.
+
+---
+
+Thanks to all the speakers and organizers for making this meetup a success!
+
+Meeting minutes contributed by **Gopinath P**.

--- a/content/june-2020-meeting-minutes.md
+++ b/content/june-2020-meeting-minutes.md
@@ -1,0 +1,66 @@
+Title: Meeting Minutes of 6/27/2020 ChennaiPy
+Date: 2020-06-27 16:00
+Tags: Meeting Minutes
+Summary: The June 2020 ChennaiPy meetup included talks on **Role of Python in ETL**, **Cyclic Redundancy Check (CRC)**, and several open slots with interesting suggestions.
+
+# ChennaiPy June 2020 Meetup - Meeting Minutes
+
+The meetup took place on **June 27, 2020**, at **Chennai**.
+
+---
+
+### Talk 1: Role of Python in ETL
+**Speaker:** Deepak
+
+- **ETL** (Extract, Transform, Load) - Python’s role in customizing ETL workflows due to its readability and ease of use.
+- **Python ETL Tools**:
+  - **Petl**: Example with converting a 4x2 array to HTML.
+  - **Pandas**: ETL with transformations and conditions.
+  - **Mara**: Lightweight, web-based UI.
+  - **Apache Airflow**: Created by Airbnb, uses DAGs (Directed Acyclic Graphs).
+  - **Pyspark**: Big data tool for data streaming and ML on top of streaming data.
+  - **Bonobo**: Supports parallel processing.
+  - **Luigi**: Created by Spotify, designed for enterprise-level solutions with increasing data.
+  - **AVIK Cloud**: Not open source, but Python can be implemented directly.
+
+**Q&A**:
+- **Ashok**: "Can you explain the pipeline?"
+- **Deepak**: "For enterprise-level activities, multiple parallel operations are handled by creating pipelines."
+
+---
+
+### Talk 2: Introduction to Cyclic Redundancy Check (CRC)
+**Speaker:** Ashok
+
+- **Cyclic Redundancy Check (CRC)** is used for error detection in computer networks.
+- **Types of Errors**:
+  - **Single Bit Error**
+  - **Burst Error**
+- **Error Detection**: Adding redundancy bits to transmitted data.
+  - Example: Transmitting 1000 bits from CP1 to CP2 with 125 redundancy bits.
+  - **State Machine** and **2-Dimensional Parity Check**.
+  - **Checksum**: Binary Addition.
+- **CRC Computation**: Performed using XOR in polynomial division.
+  
+**Conclusion**: CRC errors can occur when accessing the hard drive.
+
+---
+
+### Open Slot
+
+- **Ashok**: Suggested documentaries available on Netflix:
+  - **"Prediction by the Numbers"**
+  - **"The Code"** (3 episodes).
+  - Context: They provide real-life connections to mathematical concepts, like Bayes' theorem and fractals.
+  
+- **Rengaraj**: Announcement for **PyCon India 2020**.
+  
+- **Pradeep**: Suggested resources from **MIT OpenCourseWare**: [MIT OpenCourseware](https://ocw.mit.edu/index.htm).
+  
+- **Vijay Ravider**: Talked about **Python modules used in infrastructure-based provisioning services**.
+
+---
+
+The meetup concluded with a lively discussion and networking.
+
+Meeting minutes contributed by

--- a/content/november-2018-meeting-minutes.md
+++ b/content/november-2018-meeting-minutes.md
@@ -1,0 +1,72 @@
+Title: Meeting Minutes - Chennaipy Nov 2018 Meetup
+Date: 2018-11-22
+Tags: Meeting Minutes
+Summary: The meeting featured multiple talks on various Python-related topics including PyGTK, accessing spreadsheets in Python, and contributing to open-source projects.
+
+# Meeting Minutes - Chennaipy Nov 2018 Meetup
+
+## Introduction to PyGTK
+### Speaker: Ashok Kumar
+
+The author used PyGTK in their Digital Signage Project to manage many LCD and LED devices. They need to display images, videos, and webpages.
+
+They used **Xibo**, an open-source software to manage remote displays and schedule content. Each player was a remote node.
+
+### PyGTK
+- Built on the GTK+ library, PyGTK exposes most of the features available in GTK+.
+- Works on **Windows**, **MacOS**, **Linux**.
+- Several advantages over GTK+:
+  - No need to worry about pointers and memory management.
+  - Quick prototyping and easy development.
+- **Widgets**: Components for building interfaces.
+  - Control and display widgets.
+  - Containers for holding widgets (e.g., Window, frames).
+
+### Glade
+- GUI creation using drag-and-drop.
+- The exported XML can be used directly in PyGTK to build the program, saving hours of coding.
+
+## Accessing Spreadsheets in Python
+### Speaker: Praveen Kumar
+
+Praveen emphasized using **virtualenv** to clone the Python environment and avoid conflicts with the system Python.
+
+### Steps to Access Spreadsheets Programmatically:
+- Connect to the workbook.
+- Access the worksheet and read/write cells.
+- Modify and save cells.
+
+### Spreadsheet from Scratch in Python
+- Automates manual tasks.
+- Uses **MS Excel** or **LibreOffice** spreadsheets.
+- Data stored in text files (e.g., **Yaml** for version control).
+
+---
+
+## Lightning Talks
+
+### Spicing up the Command Line
+#### Speaker: Aziz
+
+Aziz demonstrated how to enhance the command line using Python libraries:
+- **getpass**: Prompt the user for a password without echoing.
+- **colorama**: Simple cross-platform API for printing colored terminal text.
+- **tabulate**: Pretty-print tabular data.
+- **tqdm**: Show a smart progress meter.
+- **jinja**: HTML formatted output.
+
+### Contributing to Open Source Projects
+#### Speaker: Karthick
+
+Karthick encouraged contribution to **Python** projects, especially for bug triaging, documentation, and community building. He emphasized that anyone can contribute without being a "coding ninja."
+
+### DataDeux
+#### Speaker: Deepak
+
+Deepak introduced **DateDeux**, a library for advanced calendar operations, including date arithmetic and finding the start/end of months.
+
+---
+
+The meetup ended with engaging talks and valuable learning opportunities for all attendees. 
+
+Meeting minutes contributed by **Suresh**. [Chennaipy Meetup](http://www.meetup.com/Chennaipy/members/4217588/).

--- a/content/november-2018-meeting-minutes1.md
+++ b/content/november-2018-meeting-minutes1.md
@@ -1,0 +1,79 @@
+Title: Meeting Minutes - Chennaipy Nov 2018 Meetup
+Date: 2018-11-22
+Tags: Meeting Minutes
+Summary: This document contains the meeting minutes from the **Chennaipy Nov 2018 Meetup**.
+
+# Meeting Minutes - Chennaipy Nov 2018 Meetup
+
+Hi Sharmila, thanks for the detailed take on the event!
+
+Regards,  
+Vijay Kumar
+
+---
+
+## Introduction to PyGTK
+### Speaker: Ashok Kumar
+
+The author used PyGTK in their Digital Signage Project to manage many LCD and LED devices. They need to display images, videos, and webpages.
+
+They used **Xibo**, an open-source software to manage remote displays and schedule content. Each player was a remote node.
+
+### PyGTK
+- Built on the GTK+ library, PyGTK exposes most of the features available in GTK+.
+- Works on **Windows**, **MacOS**, **Linux**.
+- Several advantages over GTK+:
+  - No need to worry about pointers and memory management.
+  - Quick prototyping and easy development.
+- **Widgets**: Components for building interfaces.
+  - Control and display widgets.
+  - Containers for holding widgets (e.g., Window, frames).
+
+### Glade
+- GUI creation using drag-and-drop.
+- The exported XML can be used directly in PyGTK to build the program, saving hours of coding.
+
+## Accessing Spreadsheets in Python
+### Speaker: Praveen Kumar
+
+Praveen emphasized using **virtualenv** to clone the Python environment and avoid conflicts with the system Python.
+
+### Steps to Access Spreadsheets Programmatically:
+- Connect to the workbook.
+- Access the worksheet and read/write cells.
+- Modify and save cells.
+
+### Spreadsheet from Scratch in Python
+- Automates manual tasks.
+- Uses **MS Excel** or **LibreOffice** spreadsheets.
+- Data stored in text files (e.g., **Yaml** for version control).
+
+---
+
+## Lightning Talks
+
+### Spicing up the Command Line
+#### Speaker: Aziz
+
+Aziz demonstrated how to enhance the command line using Python libraries:
+- **getpass**: Prompt the user for a password without echoing.
+- **colorama**: Simple cross-platform API for printing colored terminal text.
+- **tabulate**: Pretty-print tabular data.
+- **tqdm**: Show a smart progress meter.
+- **jinja**: HTML formatted output.
+
+### Contributing to Open Source Projects
+#### Speaker: Karthick
+
+Karthick encouraged contribution to **Python** projects, especially for bug triaging, documentation, and community building. He emphasized that anyone can contribute without being a "coding ninja."
+
+### DataDeux
+#### Speaker: Deepak
+
+Deepak introduced **DateDeux**, a library for advanced calendar operations, including date arithmetic and finding the start/end of months.
+
+---
+
+The meetup ended with engaging talks and valuable learning opportunities for all attendees. 
+
+Meeting minutes contributed by **Suresh**. [Chennaipy Meetup](http://www.meetup.com/Chennaipy/members/4217588/).

--- a/content/november-2019-meeting-minutes.md
+++ b/content/november-2019-meeting-minutes.md
@@ -1,0 +1,66 @@
+Title: Minutes of Meetup - 23 Nov 2019
+Date: 2019-11-23 16:00
+Tags: Meeting Minutes
+Summary: The November 2019 Chennaipy meetup included talks on **Embedded Testing with Robot Framework**, **Teaching Kids Python the Scratch Way**, and **Data Compression Techniques using Python**.
+
+# ChennaiPy November 2019 Meetup - Meeting Minutes
+
+The meetup took place on **November 23, 2019** at **Chennai**.
+
+---
+
+### Talk 1: Embedded Testing with Robot Framework
+**Speaker:** Rengaraj D
+
+- **Problem Statement**: Automating the testing of an **intruder detection alarm system**.
+- **Components**:
+  - **TI Programmable Microcontroller**: Used in the system under test.
+  - **Reed Switch**: Detects if the door is open.
+  - **Multicolor LED**: Used as an output indicator.
+- **Demo**:
+  - Automated testing using **Energia electronics prototyping IDE** and **Robot Framework**.
+  - The initial test failed due to a bug in the intruder detection logic.
+  - After fixing the bug, the tests passed successfully.
+- **Test Case Modelling**:
+  - Ensuring system initialization to avoid false positives or negatives in test cases.
+  - Using **GPIO Python interface** for simulating inputs and reading outputs.
+  
+  [TI Microcontroller](https://www.ti.com/tool/MSP-EXP430FR2355)  
+  [Reed Switch Info](https://www.explainthatstuff.com/howreedswitcheswork.html)  
+  [Energia IDE](https://energia.nu/)  
+  [GPIO Python Interface](https://www.raspberrypi.org/documentation/usage/gpio/python/README.md)
+
+---
+
+### Talk 2: Teaching Kids Python the Scratch Way
+**Speaker:** Vijay Kumar
+
+- **Scratch**: A programming interface to help young people think creatively.
+- **Demo**:
+  - Animated a ball bouncing around the corners of a box.
+  - Created a program that emulated a paddle and bouncing ball.
+- **Scratch Programming**: Easy for kids to learn with systemic thinking.
+- **Python VM**: Vijay created a Python VM to run disassembled Scratch programs, transforming kids' Scratch abilities into Python programming.
+- **Scratch2py**: Allows Python code to coexist with Scratch programs, bridging the gap between Scratch and Python.
+
+  [Scratch](https://scratch.mit.edu/projects/editor/?tutorial=getStarted)  
+  [Scratch2py GitHub](https://github.com/bravegnu/scratch2py)
+
+---
+
+### Talk 3: Data Compression Techniques using Python
+**Speaker:** Ashok G
+
+- **History**: Data compression is influenced by early inventions like **Morse code** and Claude Shannon’s work in **Information Theory**.
+- **Need for Compression**: Essential in **Machine Learning** and **Deep Learning** to minimize storage and transmission costs.
+- **Huffman Encoding**: Explained how it reduces the size of text data using probability calculations to assign shorter codes to more frequent characters.
+- **Wireless Transmission**: Emphasized the need for data compression to make better use of the transmission medium (air).
+
+  [Shannon's Paper](https://en.wikipedia.org/wiki/A_Mathematical_Theory_of_Communication)  
+  [Huffman Coding](https://www.techiedelight.com/huffman-coding/)
+
+---
+
+The meetup concluded with interesting discussions and a networking session.
+
+Meeting minutes contributed by **Saravanan K**.

--- a/content/november-2020-meeting-minutes.md
+++ b/content/november-2020-meeting-minutes.md
@@ -1,0 +1,90 @@
+Title: Minutes of the meeting dated 28-11-2020
+Date: 2020-11-28 15:00
+Tags: Meeting Minutes
+Summary: The November 2020 ChennaiPy meetup featured talks on **Python in security testing**, **Setting up Zkarel**, **Set data structures in Python**, and **Python GC and References**.
+
+# ChennaiPy November 2020 Meetup - Meeting Minutes
+
+The meeting was held on **November 28, 2020**.
+
+---
+
+### Introduction
+
+- The meeting started with an introduction of members.
+- **Mr. Vijaykumar** briefed the attendees about the purpose of the meetup.
+
+---
+
+### Talk 1: Python in Security Testing
+**Speaker:** Deepak
+
+- Discussed various Python libraries used in **security testing** for applications.
+- **Key Aspects of Testing**:
+  - Authentication
+  - Authorization
+  - Availability
+  - Confidentiality
+  - Integrity
+- **Techniques**: Introduced popular testing techniques and tools like:
+  - **OWASP**
+  - **ZAP**
+  - **WFuzz**
+  - **Wapiti**
+  - **W3AF**
+
+---
+
+### Talk 2: Setting Up Zkarel
+**Speaker:** Mr. Rengaraj
+
+- **ZKarel Framework**: A framework designed to help learn Python through a simple game.
+- **Karel Simulator**: The game is simulated using this tool to teach programming concepts.
+- Explained how to set up **Zkarel** and how it can be used to teach Python programming to kids.
+
+---
+
+### Talk 3: Use of Set Data Structures in Python
+**Speaker:** Mr. Muralidharan
+
+- **Set**: A collection of unordered unique elements.
+  - **Set Properties**: Iterable and mutable.
+  - **Methods**: Add, update, remove, discard, and clear.
+  - **Operations**: Union, intersection, difference, and symmetric difference.
+- **Applications**: Sets are used in various fields like:
+  - Data analytics
+  - Machine learning
+  - Other areas requiring unique elements.
+
+---
+
+### Talk 4: Python GC and References
+**Speaker:** Mr. Vijaykumar
+
+- Illustrated a mysterious bug encountered in **Kivy applications**.
+- The issue was related to **memory referencing**.
+- **Referencing**:
+  - Showed examples using the **sys module**.
+  - Compared **referencing** and **weak referencing**.
+  - Demonstrated a solution to correct the bug in Kivy applications.
+
+---
+
+### Discussion on Meetup Format
+
+- **Deepak** suggested a change in the format of the meetup to include longer duration talks.
+- After discussion, it was decided that the current format would continue, and special sessions with longer durations may be conducted when needed.
+
+---
+
+### Vote of Thanks
+
+- **Mr. Rengaraj** proposed a vote of thanks to conclude the session.
+
+---
+
+The meeting was wrapped up with a **summation** and concluded successfully.
+
+Meeting minutes contributed by **Dr. M. Muralidharan**.
+
+---

--- a/content/october-2018-meeting-minutes.md
+++ b/content/october-2018-meeting-minutes.md
@@ -1,0 +1,36 @@
+Title: MOM - October 2018 Chennaipy Meetup
+Date: 2018-10-27 16:00
+Tags: Meeting Minutes
+Summary: The October 2018 Chennaipy meetup featured talks on **Computer Vision in Test Automation using Robot Framework** and **Scientific Computing using Python**.
+
+# MOM - October 2018 Chennaipy Meetup
+
+The meetup took place at **BOT VFX** on **October 27, 2018**, from **4 PM to 6:30 PM**.
+
+---
+
+### Talk 1: Computer Vision in Test Automation using Robot Framework
+**Speaker:** Vijayakumar
+
+- **Introduction to Testing**: Various types of testing like Unit Testing and Integration Testing were explained.
+- **Demo of Integration Testing**: Testing of the **Orpat digital Alarm Clock** using computer vision and the Robot Framework.
+- **Input Automation**: Automated the input buttons (hour, minute, set, power off) of the clock using relay control connected via the serial port.
+- **Capturing LCD Output**: Used a Document Camera to capture the LCD output, which was processed using **ffmpeg** and passed to the **SSOCR library** for reading the clock display.
+- **Robot Framework Test Suite**: A Robot-based test suite was built to automate test execution.
+- **Live Hardware Demo**: A live demo showcased the full hardware integration and testing process, making the experience amazing.
+
+---
+
+### Talk 2: Scientific Computing using Python
+**Speaker:** Ashok Govindarajan
+
+- **Simulation of Wireless Channel Attenuation**: Explained the importance of simulation in scientific computing using **scipy** and **numpy**.
+- **Concepts Covered**: Introduced concepts like **probability distribution functions**, particularly **Poisson distribution**, used for modeling waiting times in queues.
+- **Conclusion**: **Scientific computing** = **Statistics + Probability**.
+- **Demo**: Demonstrated a program that simulates wireless channel disturbances and the audience was introduced to **numpy**, **scipy**, and **matplotlib**.
+
+---
+
+The meetup ended with engaging discussions and an opportunity to interact with the speakers.
+
+Meeting minutes contributed by **Kamesh Jayachandran**.

--- a/content/september-2018-meeting-minutes.md
+++ b/content/september-2018-meeting-minutes.md
@@ -1,0 +1,55 @@
+Title: MOM - September 2018 Chennaipy Meetup
+Date: 2018-09-22 16:00
+Tags: Meeting Minutes
+Summary: The September 2018 Chennaipy meetup covered a variety of topics, including data compression, last-mile problems in ML, and Pysangamam lessons.
+
+# MOM - September 2018 Chennaipy Meetup
+
+The meeting took place on **September 22, 2018**, from **4 PM to 6:45 PM**.
+
+---
+
+### Talk 1: Data Compression Techniques
+**Speaker:** Bharathwaaj S
+
+- Data compression involves minimizing the byte size without degrading quality.
+- **Lossy** and **lossless** data compressions were discussed.
+- **Information theory** and its application to data compression (Huffman Coding) were explored.
+- A fun fact: Data compression methods were already used in **Morse code** in 1836 before Shannon formalized them in 1948.
+
+---
+
+### Talk 2: Last Mile Problem in Machine Learning
+**Speaker:** Vijay Kumar
+
+- **ML Model Tracking**: Discussed the importance of tracking training data, code, hyperparameters, and results for reproducibility.
+- **MLFlow** was introduced as a tool to help manage ML experiments.
+- Importance of organizing code and exposing models like libraries.
+- Deployed models to **AWS SageMaker**.
+
+---
+
+### Talk 3: Pysangamam - Lessons Learnt
+**Speaker:** Bharathwaaj S
+
+- **Event Recap**: Timeline included 2 keynotes, 16 20-minute slots, 16 poster slots, and 12 lightning talks.
+- Key takeaways: 
+  - **Zen of Event Planning**: Start local > national > international.
+  - Prototype before implementation and focus on quality.
+  - Rehearsals and well-managed time ensured a positive reception.
+- Challenges: Sponsorship difficulties, lack of volunteers, and the need for better planning of logistics like food.
+
+---
+
+### Talk 4: Importance of Unit Testing
+**Speaker:** Vijay Kumar
+
+- **Unit testing** is crucial for stable software and preventing regressions.
+- Discussed **mocking** external dependencies and using tools like **pytest** and **flake8**.
+- Importance of logging in databases for disaster recovery.
+
+---
+
+The meetup concluded with interactive discussions and feedback from the attendees. 
+
+Meeting minutes contributed by **Bharathwaaj S**.


### PR DESCRIPTION
This pull request converts the meeting minutes from June 2018 to November 2020 to Markdown format for better readability and consistency.

Changes Made:

Converted 13 meeting minutes files from plain text to Markdown format.
Ensured proper Markdown syntax for headings, lists, and formatting.
Improved readability with consistent styling for dates, titles, and tags.
Reason for Change:

Markdown format makes the meeting minutes more structured, visually appealing, and easier to maintain. This change also aligns with the repository's standard for documentation.

Impact:

No breaking changes.
Enhances the accessibility and presentation of meeting minutes.